### PR TITLE
Define slice name for etcd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ etcd_arch_translation:
 ## System info
 etcd_system_user_name: etcd
 etcd_system_group_name: etcd
+etcd_system_slice_name: etcd
 etcd_system_shell: /bin/false
 etcd_system_comment: etcd system user
 etcd_system_user_home: "/var/lib/{{ etcd_system_user_name }}"

--- a/tasks/etcd_post_install_gateway.yml
+++ b/tasks/etcd_post_install_gateway.yml
@@ -21,6 +21,7 @@
     systemd_RestartSec: 10
     systemd_user_name: "{{ etcd_system_user_name }}"
     systemd_group_name: "{{ etcd_system_group_name }}"
+    systemd_slice_name: "{{ etcd_systemd_slice_name }}"
     systemd_services:
       - service_name: etcd-gateway
         service_type: notify

--- a/tasks/etcd_post_install_server.yml
+++ b/tasks/etcd_post_install_server.yml
@@ -45,6 +45,7 @@
     systemd_RestartSec: 10
     systemd_user_name: "{{ etcd_system_user_name }}"
     systemd_group_name: "{{ etcd_system_group_name }}"
+    systemd_slice_name: "{{ etcd_system_slice_name }}"
     systemd_services:
       - service_name: etcd
         service_type: notify


### PR DESCRIPTION
Nowadays systemd role defines lock dir based on the slice name.
In order to have valid lock directory owner and path we define
slice name for etcd.