### PR TITLE
Remove static keyword

### DIFF
--- a/tasks/etcd_post_install_server.yml
+++ b/tasks/etcd_post_install_server.yml
@@ -23,7 +23,6 @@
     - etcd-config
 
 - include: etcd_post_install_ssl.yml
-  static: false
   when:
     - "{{ etcd_user_ssl_cert is defined }}"
     - "{{ etcd_user_ssl_key is defined }}"


### PR DESCRIPTION
Static has been deprecated and removed from ansible-core 2.12
To be compatible with modern ansible we remove that