### PR TITLE
Replace legacy API healthcheck

### DIFF
--- a/tasks/etcd_post_install_server.yml
+++ b/tasks/etcd_post_install_server.yml
@@ -62,14 +62,15 @@
             LimitNOFILE: 65536
 
 - name: Verify etcd cluster health
-  command: etcdctl cluster-health
+  uri:
+    url: "{{ etcd_url_scheme }}://127.0.0.1:{{ etcd_client_port }}/health"
+    return_content: true
   register: etcd_health
-  failed_when: etcd_health.rc != 0
+  failed_when: "'true' not in etcd_health.content"
   changed_when: false
   until: etcd_health is success
   retries: 5
   delay: 2
-  when: inventory_hostname == groups[etcd_cluster_group][0]
   tags:
     - etcd-config
     - etcd-verify


### PR DESCRIPTION
As from version 3.4 ETCDCTL_API=3 is the default so cluster-health command does not work.

This PR has been taken from https://github.com/logan2211/ansible-etcd/pull/19