### PR TITLE
Replace deprecated include with proper statements

### DIFF
--- a/tasks/etcd_post_install_server.yml
+++ b/tasks/etcd_post_install_server.yml
@@ -22,7 +22,7 @@
   tags:
     - etcd-config
 
-- include: etcd_post_install_ssl.yml
+- include_tasks: etcd_post_install_ssl.yml
   when:
     - "{{ etcd_user_ssl_cert is defined }}"
     - "{{ etcd_user_ssl_key is defined }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: etcd_install.yml
-- include: "etcd_post_install_{{ etcd_install_type }}.yml"
+- import_tasks: etcd_install.yml
+- include_tasks: "etcd_post_install_{{ etcd_install_type }}.yml"


### PR DESCRIPTION
Include statement has been deprecated for a while and should be replaced
with either include_tasks or import_tasks.